### PR TITLE
[FIX] - failing heroku deployment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,8 +238,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   factory_girl_rails
-  haml
-  haml-rails (~> 0.9)
+  haml-rails
   jbuilder (~> 2.5)
   jquery-rails
   launchy


### PR DESCRIPTION
Solve failing deploy due to this error by heroku
```
You are trying to install in deployment mode after changing your Gemfile. Run `bundle install` elsewhere and add the updated Gemfile.lock to version control.
```
Have to push this commit directly to heroku to enable other builds to be deployed.