### PR TITLE
[Fix] foundation styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ The site address [https://slowfood-online-feb-17.herokuapp.com](https://slowfood
 
 * Dependencies:
   - acts as shoppingcart gem
-  - devise gem 
+  - devise gem

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,3 +1,9 @@
+/*
+*= require_tree .
+*= require_self
+*= require foundation_and_overrides
+*/
+
 .alert {
    background-color: #f2dede ;
    border-color: #eed3d7 ;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -3,17 +3,3 @@
 *= require_self
 *= require foundation_and_overrides
 */
-
-.alert {
-   background-color: #f2dede ;
-   border-color: #eed3d7 ;
-   color: #b94a48 ;
-   text-align: left;
-}
-
-.notice {
-   background-color: #dff0d8 ;
-   border-color: #d6e9c6 ;
-   color: #468847 ;
-   text-align: left;
-}

--- a/app/assets/stylesheets/base.css.scss
+++ b/app/assets/stylesheets/base.css.scss
@@ -52,3 +52,18 @@ footer {
     }
   }
 }
+
+// alert for the flash (this might be changed once foundation is integrated)
+.alert {
+    background-color: #f2dede ;
+    border-color: #eed3d7 ;
+    color: #b94a48 ;
+    text-align: left;
+}
+
+.notice {
+    background-color: #dff0d8 ;
+    border-color: #d6e9c6 ;
+    color: #468847 ;
+    text-align: left;
+}


### PR DESCRIPTION
On the previous PR https://github.com/CraftAcademy/slow_food_online_feb_17/pull/13 , I accidentally removed the directives for including css assets used by sprockets.

I have also moved styling related to the flash notice out of application.scss file.